### PR TITLE
Faster enabling of an installed, but disabled BGRT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ boot*.efi
 setup.exe
 src/GIT_DESCRIBE.cs
 html
+/.vs

--- a/src/Setup.cs
+++ b/src/Setup.cs
@@ -369,7 +369,7 @@ public class Setup: SetupHelper {
 		}
 		if (waitForKeyPress) {
 			Console.WriteLine("Press any key to quit.");
-			
+			Console.ReadKey();
 		}
 	}
 }

--- a/src/Setup.cs
+++ b/src/Setup.cs
@@ -369,7 +369,7 @@ public class Setup: SetupHelper {
 		}
 		if (waitForKeyPress) {
 			Console.WriteLine("Press any key to quit.");
+			
 		}
-		Console.ReadKey();
 	}
 }

--- a/src/SetupHelper.cs
+++ b/src/SetupHelper.cs
@@ -99,6 +99,6 @@ public class SetupHelper {
 			Environment.ExitCode = 1;
 			return;
 		}
-		Setup.RunSetup(Path.GetDirectoryName(self));
+		Setup.RunSetup(Path.GetDirectoryName(self), args);
 	}
 }

--- a/src/SetupHelper.cs
+++ b/src/SetupHelper.cs
@@ -83,7 +83,7 @@ public class SetupHelper {
 			var admin = WindowsBuiltInRole.Administrator;
 			if (!principal.IsInRole(admin) && !args.Contains("no-elevate")) {
 				ProcessStartInfo startInfo = new ProcessStartInfo(self);
-				startInfo.Arguments = "no-elevate";
+				startInfo.Arguments = "no-elevate " + String.Join(" ", args);
 				startInfo.Verb = "runas";
 				startInfo.UseShellExecute = true;
 				Process p = Process.Start(startInfo);


### PR DESCRIPTION
In my experience, the BGRT gets replaced by the default during every windows update. As a windows insider on the fast update ring, I get updates pretty much every other week. This means, that my beautiful, custom boot logo only lasts for a few weeks. Having to go through the full installation process every time was getting annoying.

These commits introduce 2 new features:
1. A new option "E" to re-enable a BGRT, which was found to be installed, but not active (basically the opposite of "D"). It's basically the same as the installation, without opening the config/logo file first.
2. The very simple possibility to pass the intended keypress as command line argument (without any decoration, literally just "setup.exe E" for example). This will automatically select the given option, and close the program afterwards.

This allows me to quickly enable my nice boot logo after an update through a shortcut.
