### PR TITLE
Add clean and qemu test targets to Makefile.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ boot*.efi
 setup.exe
 src/GIT_DESCRIBE.cs
 html
+efi_test/

--- a/Makefile
+++ b/Makefile
@@ -42,3 +42,15 @@ bootia32.efi: CC_PREFIX = i686-w64-mingw32
 bootia32.efi: GNUEFI_ARCH = ia32
 bootia32.efi: $(FILES_C)
 	$(CC) $(CFLAGS) $(LDFLAGS) $^ -o $@ $(LIBS) -s
+
+clean:
+	rm -f bootx64.efi bootia32.efi
+	rm -f setup.exe
+	rm -rf efi_test/
+
+testx64-qemu: bootx64.efi config.txt splash.bmp
+	mkdir -p efi_test/EFI/HackBGRT
+	cp bootx64.efi efi_test/EFI/HackBGRT/loader.efi && echo "bootx64 okay"
+	cp config.txt splash.bmp efi_test/EFI/HackBGRT/ && echo "aux files okay"
+	qemu-system-x86_64 -L /usr/share/ovmf/ --bios OVMF.fd -drive media=disk,file=fat:rw:./efi_test,format=raw -net none -serial stdio
+	# hit escape during boot, go to Boot Manager Maintenance, select Boot From File, select QEMU VVFAT, navigate to EFI>HackBGRT>loader.efi


### PR DESCRIPTION
Selecting the loader.efi in OVMF manually is not super convenient, but at least it is a reproducible way to run the compiled EFI binary without rebooting the whole machine.

I still cannot produce a working binary on my system, but at least, this Makefile target allows me to fail faster.

Tested on vanilla Windows 11 with WSL Ubuntu and gnu-efi 3.0.11 and qemu 6.2.0.